### PR TITLE
update to 1.2.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.2.5
+
+* Replaced `menuBounceDepth` with `menuBounceDistance` in `PieTheme` and improved default bounce animation.
+* Fixed [#28](https://github.com/rasitayaz/flutter-pie-menu/issues/28)
+
 ## 1.2.4
 
 * Improved menu bounce animations.

--- a/lib/src/pie_canvas_overlay.dart
+++ b/lib/src/pie_canvas_overlay.dart
@@ -395,20 +395,22 @@ class PieCanvasOverlayState extends State<PieCanvasOverlay>
   }
 
   void _detachMenu() {
-    _pointerDownTimer?.cancel();
-    if (_menuAttached) {
-      setState(() {
-        _pressed = false;
-        _pressedAgain = false;
-        _tooltip = null;
-        _hoveredAction = null;
-        menuState = null;
-        _menuRenderBox = null;
-        _menuChild = null;
-        _menuAttached = false;
-        menuActive = false;
-      });
-    }
+    _pointerUpTimer = Timer(_theme.fadeDuration, () {
+      _pointerDownTimer?.cancel();
+      if (_menuAttached) {
+        setState(() {
+          _pressed = false;
+          _pressedAgain = false;
+          _tooltip = null;
+          _hoveredAction = null;
+          menuState = null;
+          _menuRenderBox = null;
+          _menuChild = null;
+          _menuAttached = false;
+          menuActive = false;
+        });
+      }
+    });
   }
 
   void _pointerDown(Offset offset) {
@@ -431,9 +433,7 @@ class PieCanvasOverlayState extends State<PieCanvasOverlay>
         toggleMenu(false);
         setState(() => menuActive = false);
 
-        _pointerUpTimer = Timer(_theme.fadeDuration, () {
-          _detachMenu();
-        });
+        _detachMenu();
       }
     } else {
       _detachMenu();

--- a/lib/src/pie_theme.dart
+++ b/lib/src/pie_theme.dart
@@ -27,8 +27,8 @@ class PieTheme {
     this.tooltipPadding = const EdgeInsets.symmetric(horizontal: 32),
     this.tooltipStyle,
     this.pieBounceDuration = const Duration(seconds: 1),
-    this.menuBounceDuration = const Duration(milliseconds: 100),
-    this.menuBounceDepth = 0.95,
+    this.menuBounceDuration = const Duration(milliseconds: 120),
+    this.menuBounceDistance = 24,
     this.menuBounceCurve = Curves.decelerate,
     this.menuBounceReverseCurve,
     this.fadeDuration = const Duration(milliseconds: 250),
@@ -79,9 +79,8 @@ class PieTheme {
   /// Duration of [PieMenu] bounce animation.
   final Duration menuBounceDuration;
 
-  /// Decides how small the menu child will be when it is bouncing.
-  /// A value between 0 and 1.
-  final double menuBounceDepth;
+  /// Distance of [PieMenu] bounce animation.
+  final double menuBounceDistance;
 
   /// Curve for the menu bounce animation.
   final Curve menuBounceCurve;
@@ -125,7 +124,7 @@ class PieTheme {
     TextStyle? tooltipStyle,
     Duration? pieBounceDuration,
     Duration? menuBounceDuration,
-    double? menuBounceDepth,
+    double? menuBounceDistance,
     Curve? menuBounceCurve,
     Curve? menuBounceReverseCurve,
     Duration? fadeDuration,
@@ -147,7 +146,7 @@ class PieTheme {
       tooltipStyle: tooltipStyle ?? this.tooltipStyle,
       pieBounceDuration: pieBounceDuration ?? this.pieBounceDuration,
       menuBounceDuration: menuBounceDuration ?? this.menuBounceDuration,
-      menuBounceDepth: menuBounceDepth ?? this.menuBounceDepth,
+      menuBounceDistance: menuBounceDistance ?? this.menuBounceDistance,
       menuBounceCurve: menuBounceCurve ?? this.menuBounceCurve,
       menuBounceReverseCurve:
           menuBounceReverseCurve ?? this.menuBounceReverseCurve,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pie_menu
 description: A Flutter package that provides a customizable circular/radial context menu
-version: 1.2.4
+version: 1.2.5
 homepage: https://github.com/rasitayaz/flutter-pie-menu
 repository: https://github.com/rasitayaz/flutter-pie-menu
 issue_tracker: https://github.com/rasitayaz/flutter-pie-menu/issues


### PR DESCRIPTION
* Replaced `menuBounceDepth` with `menuBounceDistance` in `PieTheme` and improved default bounce animation.
* Fixed [#28](https://github.com/rasitayaz/flutter-pie-menu/issues/28)