### PR TITLE
update to 3.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 3.1.0
+
+* Improved the child bounce animation by adding a 3D tilt effect to it inspired by [Bounce](https://pub.dev/packages/bounce) package. Can be disabled by setting `childTiltEnabled` to `false` in `PieTheme`.
+* Added `overlayStyle` to `PieTheme` to switch between the old and new overlay styles. `PieOverlayStyle.behind` (the old style) is used by default because the new one causes render issues in some cases.
+* Other minor improvements and bug fixes.
+
 ## 3.0.0
 
 * When a `PieMenu` activates, other gestures are now automatically cancelled. You no longer need to use `NeverScrollableScrollPhysics` to disable scrolling or to deactivate the functionality of your interactive menu child.

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -68,38 +68,47 @@ class _HomePageState extends State<HomePage> {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
-        title: const Text(
-          'Flutter Pie Menu 🥧',
-          style: TextStyle(fontWeight: FontWeight.w600),
+    return PieCanvas(
+      theme: const PieTheme(
+        rightClickShowsMenu: true,
+        tooltipTextStyle: TextStyle(
+          fontSize: 32,
+          fontWeight: FontWeight.w600,
         ),
       ),
-      body: IndexedStack(
-        index: _navigationIndex,
-        children: const [
-          StylingPage(),
-          ListViewPage(),
-          AboutPage(),
-        ],
-      ),
-      bottomNavigationBar: BottomNavigationBar(
-        currentIndex: _navigationIndex,
-        onTap: (index) => setState(() => _navigationIndex = index),
-        items: const [
-          BottomNavigationBarItem(
-            icon: FaIcon(FontAwesomeIcons.palette),
-            label: 'Styling',
+      child: Scaffold(
+        appBar: AppBar(
+          title: const Text(
+            'Flutter Pie Menu 🥧',
+            style: TextStyle(fontWeight: FontWeight.w600),
           ),
-          BottomNavigationBarItem(
-            icon: FaIcon(FontAwesomeIcons.list),
-            label: 'ListView',
-          ),
-          BottomNavigationBarItem(
-            icon: FaIcon(FontAwesomeIcons.circleInfo),
-            label: 'About',
-          ),
-        ],
+        ),
+        body: IndexedStack(
+          index: _navigationIndex,
+          children: const [
+            StylingPage(),
+            ListViewPage(),
+            AboutPage(),
+          ],
+        ),
+        bottomNavigationBar: BottomNavigationBar(
+          currentIndex: _navigationIndex,
+          onTap: (index) => setState(() => _navigationIndex = index),
+          items: const [
+            BottomNavigationBarItem(
+              icon: FaIcon(FontAwesomeIcons.palette),
+              label: 'Styling',
+            ),
+            BottomNavigationBarItem(
+              icon: FaIcon(FontAwesomeIcons.list),
+              label: 'ListView',
+            ),
+            BottomNavigationBarItem(
+              icon: FaIcon(FontAwesomeIcons.circleInfo),
+              label: 'About',
+            ),
+          ],
+        ),
       ),
     );
   }
@@ -358,75 +367,66 @@ class _ListViewPageState extends State<ListViewPage> {
 
   @override
   Widget build(BuildContext context) {
-    return PieCanvas(
-      theme: const PieTheme(
-        rightClickShowsMenu: true,
-        tooltipTextStyle: TextStyle(
-          fontSize: 32,
-          fontWeight: FontWeight.w600,
-        ),
+    return ListView.separated(
+      padding: EdgeInsets.only(
+        top: spacing,
+        bottom: spacing,
+        left: MediaQuery.of(context).padding.left + spacing,
+        right: MediaQuery.of(context).padding.right + spacing,
       ),
-      child: ListView.separated(
-        padding: EdgeInsets.only(
-          top: spacing,
-          bottom: spacing,
-          left: MediaQuery.of(context).padding.left + spacing,
-          right: MediaQuery.of(context).padding.right + spacing,
-        ),
-        physics: const BouncingScrollPhysics(),
-        itemCount: 16,
-        separatorBuilder: (context, index) => const SizedBox(height: spacing),
-        itemBuilder: (context, index) {
-          return SizedBox(
-            height: 200,
-            child: PieMenu(
-              onPressed: () {
-                context.showSnackBar(
-                  '#$index — Long press or right click to show the menu',
-                );
-              },
-              actions: [
-                PieAction(
-                  tooltip: const Text('Like'),
-                  onSelect: () => context.showSnackBar('Like #$index'),
-                  child: const FaIcon(FontAwesomeIcons.solidHeart),
-                ),
-                PieAction(
-                  tooltip: const Text('Comment'),
-                  onSelect: () => context.showSnackBar('Comment #$index'),
-                  child: const FaIcon(FontAwesomeIcons.solidComment),
-                ),
-                PieAction(
-                  tooltip: const Text('Save'),
-                  onSelect: () => context.showSnackBar('Save #$index'),
-                  child: const FaIcon(FontAwesomeIcons.solidBookmark),
-                ),
-                PieAction(
-                  tooltip: const Text('Share'),
-                  onSelect: () => context.showSnackBar('Share #$index'),
-                  child: const FaIcon(FontAwesomeIcons.share),
-                ),
-              ],
-              child: DecoratedBox(
-                decoration: BoxDecoration(
-                  color: Colors.orangeAccent,
-                  borderRadius: BorderRadius.circular(16),
-                ),
-                child: Center(
-                  child: Text(
-                    '#$index',
-                    style: const TextStyle(
-                      color: Colors.white,
-                      fontWeight: FontWeight.w600,
-                      fontSize: 64,
-                    ),
+      physics: const BouncingScrollPhysics(),
+      itemCount: 16,
+      separatorBuilder: (context, index) => const SizedBox(height: spacing),
+      itemBuilder: (context, index) {
+        return SizedBox(
+          height: 200,
+          child: PieMenu(
+            onPressed: () {
+              context.showSnackBar(
+                '#$index — Long press or right click to show the menu',
+              );
+            },
+            actions: [
+              PieAction(
+                tooltip: const Text('Like'),
+                onSelect: () => context.showSnackBar('Like #$index'),
+                child: const FaIcon(FontAwesomeIcons.solidHeart),
+              ),
+              PieAction(
+                tooltip: const Text('Comment'),
+                onSelect: () => context.showSnackBar('Comment #$index'),
+                child: const FaIcon(FontAwesomeIcons.solidComment),
+              ),
+              PieAction(
+                tooltip: const Text('Save'),
+                onSelect: () => context.showSnackBar('Save #$index'),
+                child: const FaIcon(FontAwesomeIcons.solidBookmark),
+              ),
+              PieAction(
+                tooltip: const Text('Share'),
+                onSelect: () => context.showSnackBar('Share #$index'),
+                child: const FaIcon(FontAwesomeIcons.share),
+              ),
+            ],
+            child: DecoratedBox(
+              decoration: BoxDecoration(
+                color: Colors.orangeAccent,
+                borderRadius: BorderRadius.circular(16),
+              ),
+              child: Center(
+                child: Text(
+                  '#$index',
+                  style: const TextStyle(
+                    color: Colors.white,
+                    fontWeight: FontWeight.w600,
+                    fontSize: 64,
                   ),
                 ),
               ),
             ),
-          );
-        },
-      ),
+          ),
+        );
+      },
     );
   }
 }

--- a/lib/src/bouncing_widget.dart
+++ b/lib/src/bouncing_widget.dart
@@ -6,6 +6,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:pie_menu/src/pie_theme.dart';
 
+/// This widget is highly inspired by [Bounce](https://pub.dev/packages/bounce)
+/// package created by [Guillaume Cendre](https://github.com/mrcendre)
 class BouncingWidget extends StatefulWidget {
   const BouncingWidget({
     super.key,

--- a/lib/src/bouncing_widget.dart
+++ b/lib/src/bouncing_widget.dart
@@ -4,15 +4,18 @@ import 'dart:ui';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
+import 'package:pie_menu/src/pie_theme.dart';
 
 class BouncingWidget extends StatefulWidget {
   const BouncingWidget({
     super.key,
+    required this.theme,
     required this.animation,
     required this.locallyPressedOffset,
     required this.child,
   });
 
+  final PieTheme theme;
   final Animation<double> animation;
   final Offset? locallyPressedOffset;
   final Widget child;
@@ -26,21 +29,19 @@ class _BouncingWidgetState extends State<BouncingWidget> {
 
   @override
   Widget build(BuildContext context) {
-    // TODO: move these to theme
-    const shouldTilt = true;
-    const scaleFactor = 0.95;
-
     return AnimatedBuilder(
       animation: widget.animation,
       builder: (context, child) {
         final v = 0.5 / max(lastSize.width, lastSize.height);
         final transform = Matrix4.identity()..setEntry(3, 2, v);
 
-        transform.scale(lerpDouble(1, scaleFactor, widget.animation.value));
+        transform.scale(
+          lerpDouble(1, widget.theme.childBounceFactor, widget.animation.value),
+        );
 
         final offset = widget.locallyPressedOffset;
 
-        if (shouldTilt && offset != null) {
+        if (widget.theme.childTiltEnabled && offset != null) {
           final x = offset.dx / lastSize.width;
           final y = offset.dy / lastSize.height;
 

--- a/lib/src/bouncing_widget.dart
+++ b/lib/src/bouncing_widget.dart
@@ -1,0 +1,114 @@
+import 'dart:math';
+import 'dart:ui';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+
+class BouncingWidget extends StatefulWidget {
+  const BouncingWidget({
+    super.key,
+    required this.animation,
+    required this.locallyPressedOffset,
+    required this.child,
+  });
+
+  final Animation<double> animation;
+  final Offset? locallyPressedOffset;
+  final Widget child;
+
+  @override
+  State<BouncingWidget> createState() => _BouncingWidgetState();
+}
+
+class _BouncingWidgetState extends State<BouncingWidget> {
+  var lastSize = Size.zero;
+
+  @override
+  Widget build(BuildContext context) {
+    // TODO: move these to theme
+    const shouldTilt = true;
+    const scaleFactor = 0.95;
+
+    return AnimatedBuilder(
+      animation: widget.animation,
+      builder: (context, child) {
+        final v = 0.5 / max(lastSize.width, lastSize.height);
+        final transform = Matrix4.identity()..setEntry(3, 2, v);
+
+        transform.scale(lerpDouble(1, scaleFactor, widget.animation.value));
+
+        final offset = widget.locallyPressedOffset;
+
+        if (shouldTilt && offset != null) {
+          final x = offset.dx / lastSize.width;
+          final y = offset.dy / lastSize.height;
+
+          const tiltAngle = pi / 10;
+
+          final xAngle = (y - 0.5) * tiltAngle;
+          final yAngle = (x - 0.5) * (-tiltAngle);
+
+          transform.rotateX(xAngle * widget.animation.value);
+          transform.rotateY(yAngle * widget.animation.value);
+        }
+
+        return Transform(
+          transform: transform,
+          origin: Offset(lastSize.width / 2, lastSize.height / 2),
+          child: _WidgetSizeWrapper(
+            onSizeChange: (newSize) {
+              if (lastSize == newSize) return;
+              setState(() => lastSize = newSize);
+            },
+            child: widget.child,
+          ),
+        );
+      },
+      child: widget.child,
+    );
+  }
+}
+
+typedef _OnWidgetSizeChange = Function(Size newSize);
+
+class _WidgetSizeRenderObject extends RenderProxyBox {
+  _WidgetSizeRenderObject(this.onSizeChange);
+
+  final _OnWidgetSizeChange onSizeChange;
+  Size? currentSize;
+
+  @override
+  void performLayout() {
+    super.performLayout();
+
+    try {
+      Size? newSize = child?.size;
+
+      if (newSize != null && currentSize != newSize) {
+        currentSize = newSize;
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          onSizeChange(newSize);
+        });
+      }
+    } catch (e) {
+      if (kDebugMode) {
+        print(e);
+      }
+    }
+  }
+}
+
+class _WidgetSizeWrapper extends SingleChildRenderObjectWidget {
+  const _WidgetSizeWrapper({
+    required this.onSizeChange,
+    required Widget super.child,
+  });
+
+  final _OnWidgetSizeChange onSizeChange;
+
+  @override
+  RenderObject createRenderObject(BuildContext context) {
+    return _WidgetSizeRenderObject(onSizeChange);
+  }
+}

--- a/lib/src/pie_canvas_core.dart
+++ b/lib/src/pie_canvas_core.dart
@@ -339,6 +339,7 @@ class PieCanvasCoreState extends State<PieCanvasCore>
                                     child: _theme.childBounceEnabled &&
                                             bounceAnimation != null
                                         ? BouncingWidget(
+                                            theme: _theme,
                                             animation: bounceAnimation,
                                             locallyPressedOffset:
                                                 _locallyPressedOffset,

--- a/lib/src/pie_canvas_core.dart
+++ b/lib/src/pie_canvas_core.dart
@@ -117,6 +117,9 @@ class PieCanvasCoreState extends State<PieCanvasCore>
   /// Last pressed offset relative to the child widget of the current menu.
   Offset? _locallyPressedOffset;
 
+  /// Tooltip widget of the currently hovered action.
+  Widget? _tooltip;
+
   /// Controls the shared state.
   PieNotifier get _notifier => PieNotifier.of(context);
 
@@ -254,9 +257,9 @@ class PieCanvasCoreState extends State<PieCanvasCore>
   Widget build(BuildContext context) {
     final menuRenderBox = _menuRenderBox;
     final hoveredAction = _state.hoveredAction;
-    final tooltip = hoveredAction == null
-        ? const SizedBox()
-        : _actions[hoveredAction].tooltip;
+    if (hoveredAction != null) {
+      _tooltip = _actions[hoveredAction].tooltip;
+    }
 
     return Material(
       type: MaterialType.transparency,
@@ -375,7 +378,7 @@ class PieCanvasCoreState extends State<PieCanvasCore>
                             )
                                 .merge(_notifier.canvasTheme.tooltipTextStyle)
                                 .merge(_theme.tooltipTextStyle),
-                            child: tooltip,
+                            child: _tooltip ?? const SizedBox(),
                           ),
                         ),
                       );
@@ -524,6 +527,7 @@ class PieCanvasCoreState extends State<PieCanvasCore>
           _locallyPressedOffset = localOffset;
           _onMenuToggle = onMenuToggle;
           _actions = actions;
+          _tooltip = null;
 
           _notifier.update(
             active: true,

--- a/lib/src/pie_menu_core.dart
+++ b/lib/src/pie_menu_core.dart
@@ -273,6 +273,8 @@ class _PieMenuCoreState extends State<PieMenuCore>
   }
 
   void _pointerUp(PointerUpEvent event) {
+    if (_useListenerForBounce) _debounce();
+
     if (_pressCanceled) return;
 
     if (_state.active && _theme.delayDuration != Duration.zero) {

--- a/lib/src/pie_menu_core.dart
+++ b/lib/src/pie_menu_core.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
+import 'package:pie_menu/src/bouncing_widget.dart';
 import 'package:pie_menu/src/pie_action.dart';
 import 'package:pie_menu/src/pie_button.dart';
 import 'package:pie_menu/src/pie_canvas.dart';
@@ -79,8 +80,8 @@ class _PieMenuCoreState extends State<PieMenuCore>
 
   /// Bounce animation for the child widget.
   late final _bounceAnimation = Tween(
-    begin: 1.0,
-    end: _theme.childBounceFactor,
+    begin: 0.0,
+    end: 1.0,
   ).animate(
     CurvedAnimation(
       parent: _bounceController,
@@ -91,6 +92,9 @@ class _PieMenuCoreState extends State<PieMenuCore>
 
   /// Offset of the press event.
   var _pressedOffset = Offset.zero;
+
+  /// Offset of the press event relative to the child widget.
+  var _locallyPressedOffset = Offset.zero;
 
   /// Button used for the press event.
   var _pressedButton = 0;
@@ -118,6 +122,7 @@ class _PieMenuCoreState extends State<PieMenuCore>
   @override
   void dispose() {
     _overlayFadeController.dispose();
+    _bounceController.dispose();
     super.dispose();
   }
 
@@ -140,34 +145,41 @@ class _PieMenuCoreState extends State<PieMenuCore>
 
     return Stack(
       children: [
-        Positioned.fill(
-          child: AnimatedBuilder(
-            animation: _overlayFadeAnimation,
-            builder: (context, child) {
-              return Opacity(
-                opacity: _overlayFadeAnimation.value,
-                child: child,
-              );
-            },
-            child: ColoredBox(color: _theme.effectiveOverlayColor),
+        if (_theme.overlayStyle == PieOverlayStyle.around)
+          Positioned.fill(
+            child: AnimatedBuilder(
+              animation: _overlayFadeAnimation,
+              builder: (context, child) {
+                return Opacity(
+                  opacity: _overlayFadeAnimation.value,
+                  child: child,
+                );
+              },
+              child: ColoredBox(color: _theme.effectiveOverlayColor),
+            ),
           ),
-        ),
         MouseRegion(
           cursor: SystemMouseCursors.click,
           child: Listener(
             onPointerDown: _pointerDown,
             onPointerMove: _pointerMove,
             onPointerUp: _pointerUp,
-            child: AnimatedBuilder(
-              animation: _bounceAnimation,
-              builder: (context, child) {
-                return Transform.scale(
-                  scale: _bounceAnimation.value,
-                  alignment: Alignment.center,
-                  child: child,
-                );
-              },
-              child: widget.child,
+            child: AnimatedOpacity(
+              opacity: _theme.overlayStyle == PieOverlayStyle.around &&
+                      _state.menuKey == _uniqueKey &&
+                      _state.active &&
+                      _state.hoveredAction != null
+                  ? _theme.childOpacityOnButtonHover
+                  : 1,
+              duration: _theme.hoverDuration,
+              curve: Curves.ease,
+              child: _theme.childBounceEnabled
+                  ? BouncingWidget(
+                      animation: _bounceAnimation,
+                      locallyPressedOffset: _locallyPressedOffset,
+                      child: widget.child,
+                    )
+                  : widget.child,
             ),
           ),
         ),
@@ -176,8 +188,11 @@ class _PieMenuCoreState extends State<PieMenuCore>
   }
 
   void _pointerDown(PointerDownEvent event) async {
-    _pressedOffset = event.position;
-    _pressedButton = event.buttons;
+    setState(() {
+      _pressedOffset = event.position;
+      _locallyPressedOffset = event.localPosition;
+      _pressedButton = event.buttons;
+    });
 
     if (_state.active) return;
 
@@ -197,7 +212,10 @@ class _PieMenuCoreState extends State<PieMenuCore>
     _notifier.canvas.attachMenu(
       rightClicked: rightClicked,
       offset: _pressedOffset,
+      localOffset: _locallyPressedOffset,
       renderBox: context.findRenderObject() as RenderBox,
+      child: widget.child,
+      bounceAnimation: _bounceAnimation,
       menuKey: _uniqueKey,
       actions: widget.actions,
       theme: _theme,
@@ -254,9 +272,11 @@ class _PieMenuCoreState extends State<PieMenuCore>
 
     _bounceStopwatch.stop();
 
-    final debounceDelay = _bounceStopwatch.elapsedMilliseconds > 100
+    final minDelayMS = _theme.delayDuration == Duration.zero ? 100 : 75;
+
+    final debounceDelay = _bounceStopwatch.elapsedMilliseconds > minDelayMS
         ? Duration.zero
-        : const Duration(milliseconds: 100);
+        : Duration(milliseconds: minDelayMS);
 
     _debounceTimer = Timer(debounceDelay, () {
       if (mounted) _bounceController.reverse();

--- a/lib/src/pie_menu_core.dart
+++ b/lib/src/pie_menu_core.dart
@@ -194,6 +194,7 @@ class _PieMenuCoreState extends State<PieMenuCore>
                 curve: Curves.ease,
                 child: _theme.childBounceEnabled
                     ? BouncingWidget(
+                        theme: _theme,
                         animation: _bounceAnimation,
                         locallyPressedOffset: _locallyPressedOffset,
                         child: widget.child,

--- a/lib/src/pie_provider.dart
+++ b/lib/src/pie_provider.dart
@@ -7,15 +7,19 @@ import 'package:pie_menu/src/pie_theme.dart';
 /// Contains variables shared between [PieCanvasCore] and [PieMenuCore].
 class PieState {
   PieState({
-    required this.active,
     required this.menuKey,
+    required this.active,
+    required this.hoveredAction,
   });
+
+  /// Unique key of the currently active menu.
+  final Key? menuKey;
 
   /// Whether any menu is currently active.
   final bool active;
 
-  /// Unique key of the currently active menu.
-  final Key? menuKey;
+  /// Whether any menu action is currently hovered.
+  final int? hoveredAction;
 }
 
 /// Provides [PieState] to [PieCanvasCore] and [PieMenuCore].
@@ -60,9 +64,10 @@ class PieNotifier extends ChangeNotifier {
   final PieTheme canvasTheme;
 
   /// Current state shared between [PieCanvasCore] and [PieMenuCore].
-  late var state = PieState(
-    active: false,
+  var state = PieState(
     menuKey: null,
+    active: false,
+    hoveredAction: null,
   );
 
   /// Current state of the [PieCanvasCore].
@@ -70,12 +75,17 @@ class PieNotifier extends ChangeNotifier {
 
   /// Updates the shared state and notifies listeners.
   void update({
-    bool? active,
     Key? menuKey,
+    bool clearMenuKey = false,
+    bool? active,
+    int? hoveredAction,
+    bool clearHoveredAction = false,
   }) {
     state = PieState(
+      menuKey: clearMenuKey ? null : menuKey ?? state.menuKey,
       active: active ?? state.active,
-      menuKey: menuKey ?? state.menuKey,
+      hoveredAction:
+          clearHoveredAction ? null : hoveredAction ?? state.hoveredAction,
     );
 
     notifyListeners();

--- a/lib/src/pie_theme.dart
+++ b/lib/src/pie_theme.dart
@@ -8,6 +8,22 @@ import 'package:pie_menu/src/pie_provider.dart';
 /// Action display anchor point for the specified custom angle in [PieTheme].
 enum PieAnchor { start, center, end }
 
+/// Decides how to display the translucent canvas overlay.
+enum PieOverlayStyle {
+  /// Displays the overlay to cover the entire canvas,
+  /// and re-renders the menu child on top of the overlay.
+  ///
+  /// This is the recommended style if your menu child is stateless.
+  behind,
+
+  /// Draws the overlay around the menu child using [CustomPainter].
+  ///
+  /// Use this style if you want to preserve the state of your menu child.
+  /// You might experience some rendering issues when the menu is partially
+  /// obscured by other widgets.
+  around;
+}
+
 /// Defines the behavior and the appearance
 /// of [PieCanvas] and [PieMenu] widgets.
 class PieTheme {
@@ -41,6 +57,7 @@ class PieTheme {
     this.tooltipUseFittedBox = false,
     this.pieBounceDuration = const Duration(seconds: 1),
     this.childBounceEnabled = true,
+    this.childTiltEnabled = true,
     this.childBounceDuration = const Duration(milliseconds: 150),
     this.childBounceFactor = 0.95,
     this.childBounceCurve = Curves.easeOutCubic,
@@ -50,6 +67,8 @@ class PieTheme {
     this.delayDuration = const Duration(milliseconds: 350),
     this.leftClickShowsMenu = true,
     this.rightClickShowsMenu = false,
+    this.overlayStyle = PieOverlayStyle.behind,
+    this.childOpacityOnButtonHover = 0.5,
   });
 
   /// How the background and tooltip widgets should be displayed
@@ -128,6 +147,11 @@ class PieTheme {
   /// Whether to bounce the [PieMenu] child on press.
   final bool childBounceEnabled;
 
+  /// Whether to tilt the [PieMenu] child on press.
+  ///
+  /// Only works if [childBounceEnabled] is set to true.
+  final bool childTiltEnabled;
+
   /// Duration of menu child bounce animation.
   final Duration childBounceDuration;
 
@@ -156,6 +180,19 @@ class PieTheme {
 
   /// Whether to display the menu on right mouse click.
   final bool rightClickShowsMenu;
+
+  /// Decides how to display the translucent canvas overlay.
+  ///
+  /// [PieOverlayStyle.behind] is the recommended style
+  /// if your menu child is stateless.
+  ///
+  /// Use [PieOverlayStyle.around] if you want to preserve the state of your
+  /// menu child. However, you might experience some rendering issues
+  /// when the menu is partially obscured by other widgets.
+  final PieOverlayStyle overlayStyle;
+
+  /// Opacity of the menu child when a button is hovered.
+  final double childOpacityOnButtonHover;
 
   /// Displacement distance of [PieButton]s when hovered.
   double get hoverDisplacement => buttonSize / 8;
@@ -198,6 +235,7 @@ class PieTheme {
     bool? tooltipUseFittedBox,
     Duration? pieBounceDuration,
     bool? childBounceEnabled,
+    bool? childTiltEnabled,
     Duration? childBounceDuration,
     double? childBounceDistance,
     Curve? childBounceCurve,
@@ -207,6 +245,8 @@ class PieTheme {
     Duration? delayDuration,
     bool? leftClickShowsMenu,
     bool? rightClickShowsMenu,
+    PieOverlayStyle? overlayStyle,
+    double? childOpacityOnButtonHover,
   }) {
     return PieTheme(
       brightness: brightness ?? this.brightness,
@@ -232,6 +272,7 @@ class PieTheme {
       tooltipUseFittedBox: tooltipUseFittedBox ?? this.tooltipUseFittedBox,
       pieBounceDuration: pieBounceDuration ?? this.pieBounceDuration,
       childBounceEnabled: childBounceEnabled ?? this.childBounceEnabled,
+      childTiltEnabled: childTiltEnabled ?? this.childTiltEnabled,
       childBounceDuration: childBounceDuration ?? this.childBounceDuration,
       childBounceFactor: childBounceDistance ?? childBounceFactor,
       childBounceCurve: childBounceCurve ?? this.childBounceCurve,
@@ -242,6 +283,9 @@ class PieTheme {
       delayDuration: delayDuration ?? this.delayDuration,
       leftClickShowsMenu: leftClickShowsMenu ?? this.leftClickShowsMenu,
       rightClickShowsMenu: rightClickShowsMenu ?? this.rightClickShowsMenu,
+      overlayStyle: overlayStyle ?? this.overlayStyle,
+      childOpacityOnButtonHover:
+          childOpacityOnButtonHover ?? this.childOpacityOnButtonHover,
     );
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pie_menu
 description: A Flutter package providing a highly customizable circular/radial context menu
-version: 3.0.0
+version: 3.1.0
 homepage: https://github.com/rasitayaz/flutter-pie-menu
 repository: https://github.com/rasitayaz/flutter-pie-menu
 issue_tracker: https://github.com/rasitayaz/flutter-pie-menu/issues


### PR DESCRIPTION
* Improved the child bounce animation by adding a 3D tilt effect to it inspired by [Bounce](https://pub.dev/packages/bounce) package. Can be disabled by setting `childTiltEnabled` to `false` in `PieTheme`.
* Added `overlayStyle` to `PieTheme` to switch between the old and new overlay styles. `PieOverlayStyle.behind` (the old style) is used by default because the new one causes render issues in some cases.
* Other minor improvements and bug fixes.