### PR TITLE
Render actions from center of the menu, closes #50

### DIFF
--- a/lib/src/pie_canvas_core.dart
+++ b/lib/src/pie_canvas_core.dart
@@ -488,6 +488,8 @@ class PieCanvasCoreState extends State<PieCanvasCore>
   }
 
   bool _isBeyondPointerBounds(Offset offset) {
+    if (_theme.alwaysPlaceActionsFromCenter) return false;
+
     return (_pointerOffset - offset).distance > _theme.pointerSize / 2;
   }
 

--- a/lib/src/pie_canvas_core.dart
+++ b/lib/src/pie_canvas_core.dart
@@ -514,7 +514,13 @@ class PieCanvasCoreState extends State<PieCanvasCore>
 
     if (!_pressed) {
       _pressed = true;
-      _pointerOffset = offset;
+      if (_theme.alwaysPlaceActionsFromCenter) {
+        _pointerOffset = offset -
+            localOffset +
+            Offset(renderBox.size.width * 0.5, renderBox.size.height * 0.5);
+      } else {
+        _pointerOffset = offset;
+      }
 
       _attachTimer = Timer(
         rightClicked ? Duration.zero : _theme.delayDuration,

--- a/lib/src/pie_canvas_core.dart
+++ b/lib/src/pie_canvas_core.dart
@@ -515,6 +515,14 @@ class PieCanvasCoreState extends State<PieCanvasCore>
     if (!_pressed) {
       _pressed = true;
       if (_theme.alwaysPlaceActionsFromCenter) {
+        if (!renderBox.hasSize) {
+          throw Exception(
+            'The current RenderBox doesn\'t have a size.\n'
+            'Please do not use `alwaysPlaceActionsFromCenter` here\n\n'
+            'For more information, see the pie_menu documentation.\n'
+            'https://pub.dev/packages/pie_menu',
+          );
+        }
         _pointerOffset = offset -
             localOffset +
             Offset(renderBox.size.width * 0.5, renderBox.size.height * 0.5);

--- a/lib/src/pie_theme.dart
+++ b/lib/src/pie_theme.dart
@@ -48,6 +48,7 @@ class PieTheme {
     this.angleOffset = 0,
     this.customAngle,
     this.customAngleAnchor = PieAnchor.center,
+    this.alwaysPlaceActionsFromCenter = false,
     this.buttonSize = 56,
     this.pointerSize = 40,
     this.tooltipPadding = const EdgeInsets.all(32),
@@ -115,6 +116,10 @@ class PieTheme {
 
   /// Action display alignment for the specified [customAngle].
   final PieAnchor customAngleAnchor;
+
+  /// Ignores pointer offset and places actions from the center
+  /// of the button.
+  final bool alwaysPlaceActionsFromCenter;
 
   /// Size of [PieButton] circle.
   final double buttonSize;

--- a/lib/src/pie_theme.dart
+++ b/lib/src/pie_theme.dart
@@ -231,6 +231,7 @@ class PieTheme {
     double? angleOffset,
     double? customAngle,
     PieAnchor? customAngleAnchor,
+    bool? alwaysPlaceActionsFromCenter,
     double? buttonSize,
     double? pointerSize,
     EdgeInsets? tooltipPadding,
@@ -267,6 +268,8 @@ class PieTheme {
       angleOffset: angleOffset ?? this.angleOffset,
       customAngle: customAngle ?? this.customAngle,
       customAngleAnchor: customAngleAnchor ?? this.customAngleAnchor,
+      alwaysPlaceActionsFromCenter:
+          alwaysPlaceActionsFromCenter ?? this.alwaysPlaceActionsFromCenter,
       buttonSize: buttonSize ?? this.buttonSize,
       pointerSize: pointerSize ?? this.pointerSize,
       tooltipPadding: tooltipPadding ?? this.tooltipPadding,


### PR DESCRIPTION
See #50 for details.

Adds `alwaysPlaceActionsFromCenter` bool member on `PieTheme`. Defaults to `false`, which will not affect the current behaviour in any way. When set to `true`, forces the actions to be drawn from the center, always. See #50, picture 3 for demonstration.

* This isn't a breaking change.
* This hasn't been tested enough, but should be good to go.
* Tried with `ListView` children, and other sized widgets.