### PR TITLE
3.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 3.3.0
+
+* Deprecated `delayDuration` in `PieTheme` in favor of `regularPressShowsMenu`, `longPressShowsMenu` and `longPressDuration`. If you were previously using `delayDuration` to show the menu on regular press, you can now use `regularPressShowsMenu` instead.
+* Fixed potential memory leak caused by `LongPressGestureRecognizer` not being disposed properly.
+
 ## 3.2.10
 
 * Performance improvements.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ A Flutter package providing a highly customizable circular/radial context menu, 
     - [Custom button widgets](#custom-button-widgets)
     - [Display angle of menu buttons](#display-angle-of-menu-buttons)
     - [Specific menu position](#specific-menu-position)
-    - [Tap, long press or right click to open the menu](#tap-long-press-or-right-click-to-open-the-menu)
+    - [Regular press, long press or right click to open the menu](#regular-press-long-press-or-right-click-to-open-the-menu)
   - [Controllers and callbacks](#controllers-and-callbacks)
   - [Contributing](#contributing)
   - [Donation](#donation)
@@ -165,13 +165,15 @@ PieTheme(
 ),
 ```
 
-### Tap, long press or right click to open the menu
+### Regular press, long press or right click to open the menu
 
-Set `delayDuration` of your theme to `Duration.zero` to open the menu instantly on tap.
+Use `regularPressShowsMenu`, `longPressShowsMenu` and `longPressDuration` attributes of `PieTheme` to customize the menu opening behavior.
 
 ```dart
 PieTheme(
-  delayDuration: Duration.zero,
+  regularPressShowsMenu: true,
+  longPressShowsMenu: true,
+  longPressDuration: const Duration(milliseconds: 500),
 ),
 ```
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -124,7 +124,7 @@ class StylingPage extends StatelessWidget {
   Widget build(BuildContext context) {
     return PieCanvas(
       theme: const PieTheme(
-        delayDuration: Duration.zero,
+        regularPressShowsMenu: true,
         tooltipTextStyle: TextStyle(
           fontSize: 32,
           fontWeight: FontWeight.w600,
@@ -434,7 +434,7 @@ class AboutPage extends StatelessWidget {
   Widget build(BuildContext context) {
     return PieCanvas(
       theme: PieTheme(
-        delayDuration: Duration.zero,
+        regularPressShowsMenu: true,
         tooltipTextStyle: const TextStyle(
           fontSize: 32,
           fontWeight: FontWeight.w600,

--- a/example/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/example/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -59,6 +59,7 @@
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
+      enableGPUValidationMode = "1"
       allowLocationSimulation = "YES">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">

--- a/example/macos/Runner/AppDelegate.swift
+++ b/example/macos/Runner/AppDelegate.swift
@@ -1,9 +1,13 @@
 import Cocoa
 import FlutterMacOS
 
-@NSApplicationMain
+@main
 class AppDelegate: FlutterAppDelegate {
   override func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
+    return true
+  }
+
+  override func applicationSupportsSecureRestorableState(_ app: NSApplication) -> Bool {
     return true
   }
 }

--- a/lib/src/pie_canvas_core.dart
+++ b/lib/src/pie_canvas_core.dart
@@ -576,31 +576,28 @@ class PieCanvasCoreState extends State<PieCanvasCore>
       _pressedOffset = offset ?? _pointerOffset;
       _localPointerOffset = renderBox.globalToLocal(_pointerOffset);
 
-      _attachTimer = Timer(
-        rightClicked ? Duration.zero : _theme.delayDuration,
-        () {
-          _detachTimer?.cancel();
+      _attachTimer = Timer(Duration.zero, () {
+        _detachTimer?.cancel();
 
-          _buttonBounceController.forward(from: 0);
-          _fadeController.forward(from: 0);
+        _buttonBounceController.forward(from: 0);
+        _fadeController.forward(from: 0);
 
-          _menuRenderBox = renderBox;
-          _menuOffset = renderBox.localToGlobal(Offset.zero);
-          _menuChild = child;
-          _childBounceAnimation = bounceAnimation;
-          _onMenuToggle = onMenuToggle;
-          _actions = actions;
-          _tooltip = null;
+        _menuRenderBox = renderBox;
+        _menuOffset = renderBox.localToGlobal(Offset.zero);
+        _menuChild = child;
+        _childBounceAnimation = bounceAnimation;
+        _onMenuToggle = onMenuToggle;
+        _actions = actions;
+        _tooltip = null;
 
-          _notifier.update(
-            menuOpen: true,
-            menuKey: menuKey,
-            clearHoveredAction: true,
-          );
+        _notifier.update(
+          menuOpen: true,
+          menuKey: menuKey,
+          clearHoveredAction: true,
+        );
 
-          _notifyToggleListeners(menuOpen: true);
-        },
-      );
+        _notifyToggleListeners(menuOpen: true);
+      });
     }
   }
 
@@ -645,8 +642,6 @@ class PieCanvasCoreState extends State<PieCanvasCore>
   }
 
   void _pointerUp(Offset offset) {
-    _attachTimer?.cancel();
-
     if (_state.menuOpen) {
       if (_pressedAgain || _isBeyondPointerBounds(offset)) {
         final hoveredAction = _state.hoveredAction;
@@ -660,7 +655,7 @@ class PieCanvasCoreState extends State<PieCanvasCore>
 
         _detachMenu();
       }
-    } else {
+    } else if (!_theme.regularPressShowsMenu) {
       _detachMenu();
     }
 

--- a/lib/src/pie_theme.dart
+++ b/lib/src/pie_theme.dart
@@ -67,12 +67,18 @@ class PieTheme {
     this.childBounceFilterQuality,
     this.fadeDuration = const Duration(milliseconds: 250),
     this.hoverDuration = const Duration(milliseconds: 250),
-    this.delayDuration = const Duration(milliseconds: 350),
+    @Deprecated(
+      "Deprecated in favor of 'regularPressShowsMenu', 'longPressShowsMenu' and 'longPressDuration'",
+    )
+    Duration? delayDuration,
+    Duration longPressDuration = const Duration(milliseconds: 350),
+    this.regularPressShowsMenu = false,
+    this.longPressShowsMenu = true,
     this.leftClickShowsMenu = true,
     this.rightClickShowsMenu = false,
     this.overlayStyle = PieOverlayStyle.behind,
     this.childOpacityOnButtonHover = 0.5,
-  });
+  }) : longPressDuration = delayDuration ?? longPressDuration;
 
   /// How the background and tooltip widgets should be displayed
   /// if they are not specified explicitly.
@@ -188,10 +194,14 @@ class PieTheme {
   /// Duration of [PieButton] hover animation.
   final Duration hoverDuration;
 
-  /// Long press duration for [PieMenu] to display.
-  ///
-  /// Can be set to [Duration.zero] to display the menu immediately on tap.
-  final Duration delayDuration;
+  /// Duration of long press gesture to display the menu.
+  final Duration longPressDuration;
+
+  /// Whether to display the menu on regular press.
+  final bool regularPressShowsMenu;
+
+  /// Whether to display the menu on long press.
+  final bool longPressShowsMenu;
 
   /// Whether to display the menu on left mouse click.
   final bool leftClickShowsMenu;
@@ -263,7 +273,13 @@ class PieTheme {
     FilterQuality? childBounceFilterQuality,
     Duration? fadeDuration,
     Duration? hoverDuration,
+    @Deprecated(
+      "Deprecated in favor of 'regularPressShowsMenu', 'longPressShowsMenu' and 'longPressDuration'",
+    )
     Duration? delayDuration,
+    bool? regularPressShowsMenu,
+    bool? longPressShowsMenu,
+    Duration? longPressDuration,
     bool? leftClickShowsMenu,
     bool? rightClickShowsMenu,
     PieOverlayStyle? overlayStyle,
@@ -305,7 +321,11 @@ class PieTheme {
           childBounceFilterQuality ?? this.childBounceFilterQuality,
       fadeDuration: fadeDuration ?? this.fadeDuration,
       hoverDuration: hoverDuration ?? this.hoverDuration,
-      delayDuration: delayDuration ?? this.delayDuration,
+      longPressDuration:
+          longPressDuration ?? delayDuration ?? this.longPressDuration,
+      regularPressShowsMenu:
+          regularPressShowsMenu ?? this.regularPressShowsMenu,
+      longPressShowsMenu: longPressShowsMenu ?? this.longPressShowsMenu,
       leftClickShowsMenu: leftClickShowsMenu ?? this.leftClickShowsMenu,
       rightClickShowsMenu: rightClickShowsMenu ?? this.rightClickShowsMenu,
       overlayStyle: overlayStyle ?? this.overlayStyle,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pie_menu
 description: A Flutter package providing a highly customizable circular/radial context menu
-version: 3.2.10
+version: 3.3.0
 homepage: https://github.com/rasitayaz/flutter-pie-menu
 repository: https://github.com/rasitayaz/flutter-pie-menu
 issue_tracker: https://github.com/rasitayaz/flutter-pie-menu/issues


### PR DESCRIPTION
* Deprecated `delayDuration` in `PieTheme` in favor of `regularPressShowsMenu`, `longPressShowsMenu` and `longPressDuration`. If you were previously using `delayDuration` to show the menu on regular press, you can now use `regularPressShowsMenu` instead.
* Fixed potential memory leak caused by `LongPressGestureRecognizer` not being disposed properly.