### PR TITLE
3.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 3.8.0
+
+* Added `pressCancelThreshold` to `PieTheme` to configure the pointer travel distance that cancels a tap.
+* Fixed taps being unexpectedly canceled on devices with noisy touch digitizers by raising the default press cancel threshold from `8` to `kTouchSlop` (`18`).
+
 ## 3.7.0
 
 * Added `hitTestBehavior` to `PieTheme` to allow customizing hit test behavior of the menu.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Added `pressCancelThreshold` to `PieTheme` to configure the pointer travel distance that cancels a tap.
 * Fixed taps being unexpectedly canceled on devices with noisy touch digitizers by raising the default press cancel threshold from `8` to `kTouchSlop` (`18`).
+* Parent icon theme is now respected by using `IconTheme.merge`.
 
 ## 3.7.0
 

--- a/example/android/app/build.gradle.kts
+++ b/example/android/app/build.gradle.kts
@@ -1,8 +1,16 @@
+import java.util.Properties
+
 plugins {
     id("com.android.application")
     id("kotlin-android")
     // The Flutter Gradle Plugin must be applied after the Android and Kotlin Gradle plugins.
     id("dev.flutter.flutter-gradle-plugin")
+}
+
+val keyProperties = Properties()
+val keyPropertiesFile = rootProject.file("key.properties")
+if (keyPropertiesFile.exists()) {
+    keyPropertiesFile.inputStream().use { keyProperties.load(it) }
 }
 
 android {
@@ -20,21 +28,25 @@ android {
     }
 
     defaultConfig {
-        // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId = "com.pie_menu.pie_menu_example"
-        // You can update the following values to match your application needs.
-        // For more information, see: https://flutter.dev/to/review-gradle-config.
         minSdk = flutter.minSdkVersion
         targetSdk = flutter.targetSdkVersion
         versionCode = flutter.versionCode
         versionName = flutter.versionName
     }
 
+    signingConfigs {
+        create("release") {
+            keyAlias = keyProperties["keyAlias"] as String
+            keyPassword = keyProperties["keyPassword"] as String
+            storeFile = file(keyProperties["storeFile"] as String)
+            storePassword = keyProperties["storePassword"] as String
+        }
+    }
+
     buildTypes {
         release {
-            // TODO: Add your own signing config for the release build.
-            // Signing with the debug keys for now, so `flutter run --release` works.
-            signingConfig = signingConfigs.getByName("debug")
+            signingConfig = signingConfigs.getByName("release")
         }
     }
 }

--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -1,2 +1,6 @@
 org.gradle.jvmargs=-Xmx8G -XX:MaxMetaspaceSize=4G -XX:ReservedCodeCacheSize=512m -XX:+HeapDumpOnOutOfMemoryError
 android.useAndroidX=true
+# This builtInKotlin flag was added automatically by Flutter migrator
+android.builtInKotlin=false
+# This newDsl flag was added automatically by Flutter migrator
+android.newDsl=false

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -314,7 +314,7 @@ class StylingPage extends StatelessWidget {
     );
   }
 
-  Widget _buildCard({Color? color, required IconData iconData}) {
+  Widget _buildCard({Color? color, required FaIconData iconData}) {
     return DecoratedBox(
       decoration: BoxDecoration(
         color: color,

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
     path: ../
 
   url_launcher: ^6.3.0
-  font_awesome_flutter: ^10.7.0
+  font_awesome_flutter: ^11.0.0
 
 dev_dependencies:
   flutter_test:

--- a/lib/src/pie_button.dart
+++ b/lib/src/pie_button.dart
@@ -128,7 +128,7 @@ class _PieButtonState extends State<PieButton>
                             : _buttonTheme.backgroundColor,
                       ),
                   child: Center(
-                    child: IconTheme(
+                    child: IconTheme.merge(
                       data: IconThemeData(
                         color: widget.hovered
                             ? _buttonThemeHovered.iconColor

--- a/lib/src/pie_menu_core.dart
+++ b/lib/src/pie_menu_core.dart
@@ -308,7 +308,8 @@ class _PieMenuCoreState extends State<PieMenuCore>
   void _pointerMove(PointerMoveEvent event) {
     if (!mounted || _state.menuOpen) return;
 
-    if ((_pressedOffset - event.position).distance > 8) {
+    if ((_pressedOffset - event.position).distance >
+        _theme.pressCancelThreshold) {
       _pressCanceled = true;
       _debounce();
     }

--- a/lib/src/pie_theme.dart
+++ b/lib/src/pie_theme.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:pie_menu/src/pie_button.dart';
 import 'package:pie_menu/src/pie_button_theme.dart';
@@ -79,6 +80,7 @@ class PieTheme {
     this.overlayStyle = PieOverlayStyle.behind,
     this.childOpacityOnButtonHover = 0.5,
     this.hitTestBehavior = HitTestBehavior.deferToChild,
+    this.pressCancelThreshold = kTouchSlop,
   }) : longPressDuration = delayDuration ?? longPressDuration;
 
   /// How the background and tooltip widgets should be displayed
@@ -228,6 +230,15 @@ class PieTheme {
   /// This is applied to the [GestureDetector] and [Listener] in the [PieMenu].
   final HitTestBehavior hitTestBehavior;
 
+  /// Distance in logical pixels the pointer can travel after pressing down
+  /// before the press is treated as a drag and the tap is canceled.
+  ///
+  /// Defaults to [kTouchSlop] (18). Increase this if taps are unexpectedly
+  /// canceled on devices with noisy touch digitizers (common on some older
+  /// or budget Android phones), where a stationary finger can report jitter
+  /// that exceeds the threshold.
+  final double pressCancelThreshold;
+
   /// Displacement distance of [PieButton]s when hovered.
   double get hoverDisplacement => buttonSize / 8;
 
@@ -291,6 +302,7 @@ class PieTheme {
     PieOverlayStyle? overlayStyle,
     double? childOpacityOnButtonHover,
     HitTestBehavior? hitTestBehavior,
+    double? pressCancelThreshold,
   }) {
     return PieTheme(
       brightness: brightness ?? this.brightness,
@@ -339,6 +351,7 @@ class PieTheme {
       childOpacityOnButtonHover:
           childOpacityOnButtonHover ?? this.childOpacityOnButtonHover,
       hitTestBehavior: hitTestBehavior ?? this.hitTestBehavior,
+      pressCancelThreshold: pressCancelThreshold ?? this.pressCancelThreshold,
     );
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pie_menu
 description: A Flutter package providing a highly customizable circular/radial context menu
-version: 3.7.0
+version: 3.8.0
 homepage: https://github.com/rasitayaz/flutter-pie-menu
 repository: https://github.com/rasitayaz/flutter-pie-menu
 issue_tracker: https://github.com/rasitayaz/flutter-pie-menu/issues

--- a/test/pie_button_test.dart
+++ b/test/pie_button_test.dart
@@ -69,5 +69,51 @@ void main() {
       final decoration = container.decoration as BoxDecoration;
       expect(decoration.color, Colors.red);
     });
+
+    testWidgets('overrides color and size from parent icon theme and respects '
+        'other properties', (tester) async {
+      final action = PieAction(
+        tooltip: const Text('Tooltip'),
+        onSelect: () {},
+        child: const Icon(Icons.add),
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: IconTheme(
+            data: const IconThemeData(
+              color: Colors.red,
+              size: 36.0,
+              weight: 700,
+            ),
+            child: PieCanvas(
+              child: Scaffold(
+                body: PieButton(
+                  theme: const PieTheme(
+                    iconSize: 24.0,
+                    buttonTheme: PieButtonTheme(
+                      backgroundColor: Colors.blue,
+                      iconColor: Colors.green,
+                    ),
+                  ),
+                  action: action,
+                  angle: 0,
+                  hovered: false,
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      expect(find.byIcon(Icons.add), findsOneWidget);
+
+      final iconThemeData = IconTheme.of(
+        tester.element(find.byIcon(Icons.add)),
+      );
+      expect(iconThemeData.color, Colors.green);
+      expect(iconThemeData.size, 24.0);
+      expect(iconThemeData.weight, 700);
+    });
   });
 }


### PR DESCRIPTION
* Added `pressCancelThreshold` to `PieTheme` to configure the pointer travel distance that cancels a tap.
* Fixed taps being unexpectedly canceled on devices with noisy touch digitizers by raising the default press cancel threshold from `8` to `kTouchSlop` (`18`).
* Parent icon theme is now respected by using `IconTheme.merge`.